### PR TITLE
Support AndroidX

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add dependencies in your `build.gradle`:
 	    compile 'com.github.mmin18:realtimeblurview:1.1.2'
 	}
 	android {
-		buildToolsVersion '24.0.2'                 // Use 23.0.3 or higher
+		buildToolsVersion '28.0.3'                 // Use 28.0.3 or higher
 		defaultConfig {
 			minSdkVersion 15
 			renderscriptTargetApi 19
@@ -41,7 +41,7 @@ Add dependencies in your `build.gradle`:
 Add proguard rules if necessary:
 
 ```
--keep class android.support.v8.renderscript.** { *; }
+-keep class androidx.renderscript.** { *; }
 ```
 
 # Limitations

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -16,10 +16,9 @@ allprojects {
 }
 
 ext {
-	compileSdkVersion = 27
-	buildToolsVersion = "27.0.0"
+	compileSdkVersion = 28
 	minSdkVersion = 15
-	targetSdkVersion = 27
+	targetSdkVersion = 28
 	sourceCompatibility = JavaVersion.VERSION_1_8
 	targetCompatibility = JavaVersion.VERSION_1_8
 	lintAbortOnError = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -2,10 +2,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.mmin18.realtimeblurview"
     android:versionCode="1"
-    android:versionName="1.0" >
-
-    <uses-sdk
-        android:minSdkVersion="15"
-        android:targetSdkVersion="19" />
-
-</manifest>
+    android:versionName="1.0" />

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,12 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release' // must be applied after your artifact generating plugin (eg. java / com.android.library)
 
 dependencies {
-    compile fileTree(dir: 'libs', include: '*.jar')
+    implementation fileTree(dir: 'libs', include: '*.jar')
 }
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
@@ -36,9 +35,6 @@ android {
             assets.srcDirs = ['assets']
         }
 
-        // Move the tests to tests/java, tests/res, etc...
-        instrumentTest.setRoot('tests')
-
         // Move the build types to build-types/<type>
         // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
         // This moves them out of them default location under src/<type>/... which would
@@ -55,7 +51,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.5.0'
+        classpath 'com.novoda:bintray-release:0.8.0'
     }
 }
 

--- a/library/src/com/github/mmin18/widget/RealtimeBlurView.java
+++ b/library/src/com/github/mmin18/widget/RealtimeBlurView.java
@@ -9,16 +9,17 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Rect;
-import android.support.v8.renderscript.Allocation;
-import android.support.v8.renderscript.Element;
-import android.support.v8.renderscript.RenderScript;
-import android.support.v8.renderscript.ScriptIntrinsicBlur;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewTreeObserver;
 
 import com.github.mmin18.realtimeblurview.R;
+
+import androidx.renderscript.Allocation;
+import androidx.renderscript.Element;
+import androidx.renderscript.RenderScript;
+import androidx.renderscript.ScriptIntrinsicBlur;
 
 /**
  * A realtime blurring overlay (like iOS UIVisualEffectView). Just put it above
@@ -145,7 +146,7 @@ public class RealtimeBlurView extends View {
 				try {
 					mRenderScript = RenderScript.create(getContext());
 					mBlurScript = ScriptIntrinsicBlur.create(mRenderScript, Element.U8_4(mRenderScript));
-				} catch (android.support.v8.renderscript.RSRuntimeException e) {
+				} catch (androidx.renderscript.RSRuntimeException e) {
 					if (isDebug(getContext())) {
 						if (e.getMessage() != null && e.getMessage().startsWith("Error loading RS jni library: java.lang.UnsatisfiedLinkError:")) {
 							throw new RuntimeException("Error loading RS jni library, Upgrade buildToolsVersion=\"24.0.2\" or higher may solve this issue");
@@ -341,7 +342,7 @@ public class RealtimeBlurView extends View {
 
 	static {
 		try {
-			RealtimeBlurView.class.getClassLoader().loadClass("android.support.v8.renderscript.RenderScript");
+			RealtimeBlurView.class.getClassLoader().loadClass("androidx.renderscript.RenderScript");
 		} catch (ClassNotFoundException e) {
 			throw new RuntimeException("RenderScript support not enabled. Add \"android { defaultConfig { renderscriptSupportModeEnabled true }}\" in your build.gradle");
 		}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile project(':library')
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':library')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
@@ -37,7 +36,7 @@ android {
         }
 
         // Move the tests to tests/java, tests/res, etc...
-        instrumentTest.setRoot('tests')
+        androidTest.setRoot('tests')
 
         // Move the build types to build-types/<type>
         // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...


### PR DESCRIPTION
## Overview

- [x] Support AndroidX
- [x] Drop support lib

Note that, this PR require buildtools version 28.0.3 or higher because of this [issue](https://issuetracker.google.com/issues/111948805).