### PR TITLE
Update library version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add dependencies in your `build.gradle`:
 
 ```groovy
 	dependencies {
-	    implementation 'com.github.mmin18:realtimeblurview:1.2.1'
+		implementation 'com.github.mmin18:RealtimeBlurView:master-SNAPSHOT'
 	}
 ```
 


### PR DESCRIPTION
`implementation 'com.github.mmin18:realtimeblurview:1.2.1'` is not available now, so I changed it.
After Chage, it works.